### PR TITLE
Add mpv player (optional)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,18 +4,28 @@ cmake_minimum_required(VERSION 3.0)
 
 include(FindPkgConfig)
 
+option(ENABLE_MPV "Enable MPV support" OFF)
+
 set(CMAKE_C_FLAGS "-g -DLINUX -DSDL_DISABLE_IMMINTRIN_H -DSDL_DISABLE_MMINTRIN_H -std=c99 ${CMAKE_C_FLAGS}")
 
 pkg_check_modules(SDL2 sdl2 REQUIRED)
+pkg_check_modules(SDL2_mixer SDL2_mixer REQUIRED)
+
+if(ENABLE_MPV)
+  pkg_check_modules(MPV mpv REQUIRED)
+  set(CMAKE_C_FLAGS "-DENABLE_MPV ${CMAKE_C_FLAGS}")
+  set(EXTRA_LIBS ${MPV_LIBRARIES})
+endif(ENABLE_MPV)
+
 if(NSWITCH)
   set(CMAKE_C_FLAGS "-DGLEW_NO_GLU ${CMAKE_C_FLAGS}")
   find_package(GLEW REQUIRED)
   find_library(GLEW_LIBRARY NAMES GLEW)
-  set(EXTRA_LIBS mpg123 modplug mikmod vorbisfile vorbis ogg FLAC fluidsynth opusfile opus ${GLEW_LIBRARY} stdc++)
+  set(EXTRA_LIBS ${GLEW_LIBRARY} ${EXTRA_LIBS})
 else()
   set(OpenGL_GL_PREFERENCE LEGACY)
   find_package(OpenGL REQUIRED)
-  set(EXTRA_LIBS ${OPENGL_gl_LIBRARY})
+  set(EXTRA_LIBS ${OPENGL_gl_LIBRARY} ${EXTRA_LIBS})
 endif(NSWITCH)
 
 include_directories(
@@ -29,8 +39,7 @@ add_executable(${CMAKE_PROJECT_NAME}
 )
 
 target_link_libraries(${CMAKE_PROJECT_NAME}
-  SDL2_mixer
-  ${SDL2_LIBRARIES}
+  ${SDL2_mixer_LIBRARIES}
   ${EXTRA_LIBS}
   m
 )

--- a/rvm/Core/EngineCallbacks.c
+++ b/rvm/Core/EngineCallbacks.c
@@ -31,6 +31,10 @@ void EngineCallbacks_PlayVideoFile(char* fileName)
     
     //Show video here
     
+#ifdef ENABLE_MPV
+    MpvPlayer(fileName);
+#endif
+
     waitValue = 0;
     gameMode = 9;
 }

--- a/rvm/Core/EngineCallbacks.h
+++ b/rvm/Core/EngineCallbacks.h
@@ -14,6 +14,9 @@
 #include "StageSystem.h"
 #include "ObjectSystem.h"
 #include "RenderDevice.h"
+#ifdef ENABLE_MPV
+#include "MpvPlayer.h"
+#endif
 
 void EngineCallbacks_PlayVideoFile(char* fileName);
 void EngineCallbacks_OnlineSetAchievement(int achievementID, int achievementDone);

--- a/rvm/Core/MpvPlayer.c
+++ b/rvm/Core/MpvPlayer.c
@@ -1,0 +1,192 @@
+//
+//  MpvPlayer.c
+//  rvm
+//
+
+#include "MpvPlayer.h"
+
+#ifdef ENABLE_MPV
+
+static Uint32 wakeup_on_mpv_render_update, wakeup_on_mpv_events;
+
+static void *get_proc_address_mpv(void *ctx, const char *name)
+{
+    return SDL_GL_GetProcAddress(name);
+}
+
+static void on_mpv_events(void *ctx)
+{
+    SDL_Event event = { .type = wakeup_on_mpv_events };
+    SDL_PushEvent(&event);
+}
+
+static void on_mpv_render_update(void *ctx)
+{
+    SDL_Event event = { .type = wakeup_on_mpv_render_update };
+    SDL_PushEvent(&event);
+}
+
+void MpvPlayer(char *fileName)
+{
+    // Check if fileName (with extension) exists
+    char fullName[1024];
+    snprintf(fullName, sizeof(fullName), "%s.mp4", fileName);
+    if (access(fullName, F_OK) == -1)
+    {
+        return;
+    }
+
+#ifdef __SWITCH__
+    // On Switch, MPV audio is managed by SDL
+    // As it has been initialized already, it must be deinit
+    AudioPlayback_ReleaseAudioPlayback();
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+#endif
+
+    // Retrieve current SDL_Window
+    SDL_Window *window = NULL;
+    for (int i = 0; i < 10; i++)
+    {
+        window = SDL_GetWindowFromID(i);
+        if (window)
+        {
+            break;
+        }
+    }
+
+    // MPV stuff
+    mpv_handle *mpv = mpv_create();
+    if (!mpv)
+    {
+        printf("MPV create failed\n");
+        return;
+    }
+
+    if (mpv_initialize(mpv) < 0)
+    {
+        printf("MPV init failed\n");
+        return;
+    }
+
+    mpv_render_param params[] =
+    {
+        { MPV_RENDER_PARAM_API_TYPE, MPV_RENDER_API_TYPE_OPENGL },
+        { MPV_RENDER_PARAM_OPENGL_INIT_PARAMS, &(mpv_opengl_init_params)
+            {
+                .get_proc_address = get_proc_address_mpv,
+            }
+        },
+        { MPV_RENDER_PARAM_ADVANCED_CONTROL, &(int){ 1 } },
+        { 0 }
+    };
+
+    mpv_render_context *mpv_gl;
+    if (mpv_render_context_create(&mpv_gl, mpv, params) < 0)
+    {
+        printf("Failed to initialize MPV GL context\n");
+        return;
+    }
+
+    wakeup_on_mpv_render_update = SDL_RegisterEvents(1);
+    wakeup_on_mpv_events = SDL_RegisterEvents(1);
+
+    if (wakeup_on_mpv_render_update == (Uint32)-1 || wakeup_on_mpv_events == (Uint32)-1)
+    {
+        printf("Could not register MPV events\n");
+        return;
+    }
+
+    mpv_set_wakeup_callback(mpv, on_mpv_events, NULL);
+    mpv_render_context_set_update_callback(mpv_gl, on_mpv_render_update, NULL);
+
+    const char *cmd[] = { "loadfile", fullName, NULL };
+    mpv_command_async(mpv, 0, cmd);
+
+    bool stop = false;
+
+    while (!stop)
+    {
+        SDL_Event event;
+        if (SDL_WaitEvent(&event) != 1)
+        {
+            printf("MPV event loop error\n");
+            return;
+        }
+
+        bool redraw = false;
+
+        switch (event.type)
+        {
+            case SDL_QUIT:
+            case SDL_KEYDOWN:
+            case SDL_JOYBUTTONDOWN:
+                stop = true;
+                break;
+            case SDL_WINDOWEVENT:
+                if (event.window.event == SDL_WINDOWEVENT_EXPOSED)
+                {
+                    redraw = true;
+                }
+                break;
+            default:
+                if (event.type == wakeup_on_mpv_render_update)
+                {
+                    uint64_t flags = mpv_render_context_update(mpv_gl);
+                    if (flags & MPV_RENDER_UPDATE_FRAME)
+                    {
+                        redraw = true;
+                    }
+                }
+
+                if (event.type == wakeup_on_mpv_events)
+                {
+                    bool haveEvents = true;
+                    while (haveEvents)
+                    {
+                        mpv_event *mp_event = mpv_wait_event(mpv, 0);
+                        switch (mp_event->event_id)
+                        {
+                            case MPV_EVENT_END_FILE:
+                                stop = true;
+                                break;
+                            case MPV_EVENT_NONE:
+                                haveEvents = false;
+                                break;
+                        }
+                        printf("MPV event: %s\n", mpv_event_name(mp_event->event_id));
+                    }
+                }
+                break;
+        }
+
+        if (redraw)
+        {
+            int w, h;
+            SDL_GetWindowSize(window, &w, &h);
+            mpv_render_param params[] =
+            {
+                { MPV_RENDER_PARAM_OPENGL_FBO, &(mpv_opengl_fbo)
+                    {
+                        .fbo = 0,
+                        .w = w,
+                        .h = h,
+                    }
+                },
+                { MPV_RENDER_PARAM_FLIP_Y, &(int){ 1 } },
+                { 0 }
+            };
+            mpv_render_context_render(mpv_gl, params);
+            SDL_GL_SwapWindow(window);
+        }
+    }
+
+    mpv_render_context_free(mpv_gl);
+    mpv_detach_destroy(mpv);
+
+#ifdef __SWITCH__
+    // Reinit original audio playback
+    SDL_QuitSubSystem(SDL_INIT_AUDIO);
+    InitAudioPlayback();
+#endif
+}
+#endif

--- a/rvm/Core/MpvPlayer.h
+++ b/rvm/Core/MpvPlayer.h
@@ -1,0 +1,18 @@
+//
+//  MpvPlayer.h
+//  rvm
+//
+
+#ifndef MpvPlayer_h
+#define MpvPlayer_h
+
+#ifdef ENABLE_MPV
+#include <mpv/client.h>
+#include <mpv/render_gl.h>
+#include <stdio.h>
+#include "GlobalAppDefinitions.h"
+
+void MpvPlayer(char* fileName);
+
+#endif
+#endif /* MpvPlayer_h */


### PR DESCRIPTION
Those changes add a way to play FMV throught mpv lib.

It has been tested on Linux build and Nintendo Switch.

As this lib may be absent on some plateform, the mpv support is optional and disabled by default.